### PR TITLE
Support node 0.10 through gnode

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ test('db', function*(t) {
 ```
 
 Remember that you need at least node `v0.11.2` and should pass
-`--harmony-generators` as a flag to node. Or, use the `gap` cli.
+`--harmony-generators` as a flag to node (or use [gnode](https://github.com/TooTallNate/gnode)). Or, use the `gap` cli.
 
 ## API
 
@@ -41,7 +41,7 @@ as you wish.
 
 ## CLI
 
-`gap` also comes with a cli that automatically sets the `--harmony-generators` flag for you:
+`gap` also comes with a cli that uses [gnode](https://github.com/TooTallNate/gnode) to give you generators - even on versions that do not support ES6 Generators natively.
 
 ```js
 $ gap test/*.js

--- a/bin/_gap.js
+++ b/bin/_gap.js
@@ -1,8 +1,0 @@
-#!/usr/bin/env node --harmony-generators
-
-var path = require('path');
-
-process.argv.slice(2).forEach(function(file) {
-  require(path.resolve(process.cwd(), file));
-});
-

--- a/bin/gap.js
+++ b/bin/gap.js
@@ -1,2 +1,8 @@
 #!/usr/bin/env node
-require('v8-argv')('--harmony', __dirname + '/_gap.js');
+var path = require('path');
+
+require('gnode')
+
+process.argv.slice(2).forEach(function(file) {
+  require(path.resolve(process.cwd(), file));
+});

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "co": "~3.1.0",
-    "tap": "~0.4.4",
-    "v8-argv": "~0.2.0"
+    "gnode": "0.0.8",
+    "tap": "~0.4.4"
   },
   "devDependencies": {
     "co-wait": "0.0.0"


### PR DESCRIPTION
Hey,

I'm using the gap-api right now on node 0.10, so this change makes it possible for me to use the `gap`-CLI also! :dancer: 
